### PR TITLE
Add monitoring and observability for EventBridge publishing

### DIFF
--- a/event-publisher-on-aws.php
+++ b/event-publisher-on-aws.php
@@ -417,8 +417,13 @@ class EventBridgePostEvents
             return;
         }
 
-        // Verify nonce
-        if (!isset($_GET['eventbridge_nonce']) || !wp_verify_nonce($_GET['eventbridge_nonce'], 'eventbridge_dismiss_notice')) {
+        // Sanitize and unslash nonce before verification
+        if (!isset($_GET['eventbridge_nonce'])) {
+            return;
+        }
+
+        $nonce = sanitize_text_field(wp_unslash($_GET['eventbridge_nonce']));
+        if (!wp_verify_nonce($nonce, 'eventbridge_dismiss_notice')) {
             return;
         }
 
@@ -434,8 +439,8 @@ class EventBridgePostEvents
         $this->failed_events = 0;
         $this->save_metrics();
 
-        // Redirect to remove query parameters
-        wp_redirect(remove_query_arg(array('eventbridge_dismiss_notice', 'eventbridge_nonce')));
+        // Safely redirect to remove query parameters
+        wp_safe_redirect(remove_query_arg(array('eventbridge_dismiss_notice', 'eventbridge_nonce')));
         exit;
     }
 }


### PR DESCRIPTION
Implement comprehensive metric tracking and admin notifications:

- Modified EventBridgePutEvents::sendEvent() to return success/failure status
  with detailed error information
- Added in-memory counters (successful_events, failed_events) to track metrics
- Implemented persistent storage using WordPress options table (get_option/update_option)
- Track metrics in send_post_event() and send_delete_post_event() based on sendEvent response
- Created admin notification system that displays when failure count exceeds threshold (5)
- Admin notice includes actionable information:
  - Failure count, success count, last failure time
  - Recent error message from last 10 stored failures
  - Recommended troubleshooting steps (credentials, IAM permissions, event bus)
  - Link to error logs
- Implemented dismiss capability using WordPress transients (24-hour duration)
- Reset failure counter after dismissal to prevent alert fatigue
- Only show notices to administrators (manage_options capability)
- Used WordPress nonces for secure notice dismissal

Fixed bug: Changed $post_id to $post->ID in send_post_event() API URL construction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin dashboard shows persistent failure metrics (success/failed counts), recent error details, last-failure time, and a 24-hour dismissal option.
  * Metrics persist across restarts and retain up to recent entries for troubleshooting.

* **Bug Fixes**
  * Improved event response handling and error reporting; results are now reliably classified and tracked so admin metrics reflect true delivery status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->