### PR TITLE
Add validation for EventBridge AWS credentials #7

### DIFF
--- a/event-publisher-on-aws.php
+++ b/event-publisher-on-aws.php
@@ -299,8 +299,8 @@ class EventBridgePostEvents
 
     public function __construct()
     {
-        // AWS認証情報の検証
-        if (!defined('AWS_EVENTBRIDGE_ACCESS_KEY_ID') || !defined('AWS_EVENTBRIDGE_SECRET_ACCESS_KEY')) {
+        // AWS認証情報の検証（定義されていて、空の値ではないか確認）
+        if (empty(constant('AWS_EVENTBRIDGE_ACCESS_KEY_ID')) || empty(constant('AWS_EVENTBRIDGE_SECRET_ACCESS_KEY'))) {
             add_action('admin_notices', function() {
                 ?>
                 <div class="notice notice-error">


### PR DESCRIPTION
…ctor

- Add validation check for AWS_EVENTBRIDGE_ACCESS_KEY_ID and AWS_EVENTBRIDGE_SECRET_ACCESS_KEY constants
- Display admin notice with clear error message if credentials are not defined
- Return early from constructor to prevent fatal errors when credentials are missing
- Remove duplicate display_failure_notice() and handle_notice_dismissal() methods

This prevents fatal errors when credentials are not configured and provides administrators with clear guidance on required configuration.