### PR TITLE
Add custom post type support with settings

### DIFF
--- a/assets/css/admin-settings.css
+++ b/assets/css/admin-settings.css
@@ -1,0 +1,22 @@
+/**
+ * EventBridge Post Events - Admin Settings Styles
+ */
+
+/* Post types field styles */
+.eventbridge-post-types-description {
+    margin-bottom: 10px;
+}
+
+.eventbridge-post-type-label {
+    display: block;
+    margin-bottom: 8px;
+}
+
+.eventbridge-post-type-slug {
+    font-size: 11px;
+    color: #666;
+}
+
+.eventbridge-post-types-note {
+    margin-top: 10px;
+}


### PR DESCRIPTION
- Add enabled_post_types setting to control which post types send events
- Add checkbox UI in settings page to select post types
- Filter send_post_event() to only process enabled post types
- Filter send_delete_post_event() to only process enabled post types
- Include post_type in delete event data for consistency
- Default to 'post' type only, excluding attachments from options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added selective post type publishing to control which WordPress content types generate EventBridge events.
  * New settings interface allows administrators to choose which post types trigger event publishing.
  * Default configuration publishes events for 'post' type only; additional types can be enabled as needed.
  * Event payloads now include post type information for improved filtering and categorization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->