### PR TITLE
Remove legacy format support from plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,152 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0] - 2026-01-23
+
+### ⚠️ BREAKING CHANGES
+
+#### Event Format Change: Legacy Format No Longer Supported
+
+The plugin now **only supports the Envelope format** for event payloads. The legacy format has been completely removed.
+
+**What Changed:**
+- `VALID_EVENT_FORMATS` constant now only contains `'envelope'`
+- The event_format settings field has been removed from the admin UI
+- All events are now sent in envelope format exclusively
+- The `render_event_format_field()` method has been removed
+- Settings validation now always enforces envelope format
+
+**Impact on Downstream Consumers:**
+
+If your downstream systems are consuming events from this plugin, you **must** update them to expect the envelope format.
+
+**Legacy Format (No Longer Supported):**
+```json
+{
+  "id": "123",
+  "title": "Post Title",
+  "content": "Post content",
+  "status": "publish"
+}
+```
+
+**Envelope Format (Now Required):**
+```json
+{
+  "event_id": "550e8400-e29b-41d4-a716-446655440000",
+  "event_timestamp": "2026-01-23T10:00:00+00:00",
+  "event_version": "1.0",
+  "source_system": "https://example.com",
+  "correlation_id": "550e8400-e29b-41d4-a716-446655440001",
+  "data": {
+    "id": "123",
+    "title": "Post Title",
+    "content": "Post content",
+    "status": "publish"
+  }
+}
+```
+
+### Migration Guide for Downstream Systems
+
+#### For EventBridge Rules and Targets
+
+If you have EventBridge rules that parse event properties, update your event patterns:
+
+**Before (Legacy Format):**
+```json
+{
+  "detail": {
+    "id": [{ "numeric": [123] }],
+    "status": ["publish"]
+  }
+}
+```
+
+**After (Envelope Format):**
+```json
+{
+  "detail": {
+    "data": {
+      "id": [{ "numeric": [123] }],
+      "status": ["publish"]
+    }
+  }
+}
+```
+
+#### For Lambda Functions and Event Consumers
+
+Update your event parsing code:
+
+**Before (Legacy Format):**
+```php
+$post_id = $event['detail']['id'];
+$title = $event['detail']['title'];
+$status = $event['detail']['status'];
+```
+
+**After (Envelope Format):**
+```php
+$post_id = $event['detail']['data']['id'];
+$title = $event['detail']['data']['title'];
+$status = $event['detail']['data']['status'];
+
+// Access envelope metadata
+$event_id = $event['detail']['event_id'];
+$correlation_id = $event['detail']['correlation_id'];
+$event_timestamp = $event['detail']['event_timestamp'];
+$source_system = $event['detail']['source_system'];
+```
+
+### Benefits of Envelope Format
+
+- **Traceability:** Event ID and correlation ID for tracking event flows
+- **Metadata:** Timestamp and source information for audit trails
+- **Structured Data:** Clear separation between event metadata and payload
+- **Standards Compliance:** Follows event envelope patterns used in enterprise systems
+
+### Migration Timeline
+
+- **Version 2.0.0 (Current):** Legacy format is no longer supported
+- **Action Required:** Update all downstream consumers to expect envelope format
+- **Testing:** Test EventBridge rules, Lambda functions, and other consumers with envelope format before upgrading
+
+### Removed
+
+- Legacy event format support
+- `VALID_EVENT_FORMATS` no longer includes 'legacy'
+- `render_event_format_field()` admin UI method
+- Event format setting from admin settings page
+- Conditional logic in `prepare_event_payload()` for format selection
+- Conditional logic in `handle_test_connection()` for format selection
+
+### Changed
+
+- Plugin version bumped to 2.0.0
+- `prepare_event_payload()` now always returns envelope format
+- `handle_test_connection()` now always sends envelope-wrapped test events
+- `sanitize_settings()` now enforces envelope format for all configurations
+- Test connection feature now exclusively uses envelope format
+
+### Added
+
+- Refactored test event envelope creation to use `create_event_envelope()` helper method
+- Enhanced test coverage for rejecting legacy format in settings sanitization
+
+---
+
+## [1.0] - Initial Release
+
+### Added
+
+- Initial release of EventBridge Post Events plugin
+- Support for both legacy and envelope event formats
+- Admin settings page for configuration
+- Event sending to AWS EventBridge
+- Debug logging system
+- Integration with WordPress post status transitions

--- a/event-publisher-on-aws.php
+++ b/event-publisher-on-aws.php
@@ -3,7 +3,7 @@
 Plugin Name: EventBridge Post Events
 Plugin URI: https://example.com/eventbridge-post-events
 Description: Sends events to Amazon EventBridge when WordPress posts are published, updated, or deleted
-Version: 1.0
+Version: 2.0.0
 Author: Your Name
 Author URI: https://example.com
 */
@@ -2889,14 +2889,7 @@ class EventBridgePostEvents
         );
 
         // Always use envelope format for test event
-        $test_event_payload = array(
-            'event_id' => wp_generate_uuid4(),
-            'event_timestamp' => current_time('c'),
-            'event_version' => '1.0',
-            'source_system' => get_bloginfo('url'),
-            'correlation_id' => wp_generate_uuid4(),
-            'data' => $test_event_data
-        );
+        $test_event_payload = $this->create_event_envelope($test_event_data, wp_generate_uuid4());
 
         $result = $this->get_client()->sendEvent(
             $this->get_setting('event_source_name'),

--- a/tests/integration/AdminSettingsTest.php
+++ b/tests/integration/AdminSettingsTest.php
@@ -87,7 +87,7 @@ class AdminSettingsTest extends WP_UnitTestCase
     public function test_save_send_mode_setting()
     {
         $settings = [
-            'event_format' => 'legacy',
+            'event_format' => 'envelope',
             'send_mode' => 'sync',
         ];
 
@@ -102,11 +102,11 @@ class AdminSettingsTest extends WP_UnitTestCase
      */
     public function test_settings_validation_valid_values()
     {
-        $valid_formats = ['legacy', 'envelope'];
+        $valid_formats = ['envelope'];
         $valid_modes = ['sync', 'async'];
 
         foreach ($valid_formats as $format) {
-            $this->assertContains($format, ['legacy', 'envelope']);
+            $this->assertContains($format, ['envelope']);
         }
 
         foreach ($valid_modes as $mode) {
@@ -125,7 +125,7 @@ class AdminSettingsTest extends WP_UnitTestCase
         ];
 
         // Simulate sanitization logic
-        $valid_formats = ['legacy', 'envelope'];
+        $valid_formats = ['envelope'];
         $valid_modes = ['sync', 'async'];
 
         $format_valid = in_array($invalid_settings['event_format'], $valid_formats, true);
@@ -210,18 +210,18 @@ class AdminSettingsTest extends WP_UnitTestCase
      */
     public function test_settings_update_flow()
     {
-        // Initial settings
+        // Initial settings with envelope format
         $initial = [
-            'event_format' => 'legacy',
+            'event_format' => 'envelope',
             'send_mode' => 'async',
         ];
         update_option('eventbridge_settings', $initial);
 
         // Verify initial
         $saved = get_option('eventbridge_settings');
-        $this->assertEquals('legacy', $saved['event_format']);
+        $this->assertEquals('envelope', $saved['event_format']);
 
-        // Update settings
+        // Update settings (format remains envelope)
         $updated = [
             'event_format' => 'envelope',
             'send_mode' => 'sync',

--- a/tests/integration/AdminSettingsTest.php
+++ b/tests/integration/AdminSettingsTest.php
@@ -105,10 +105,10 @@ class AdminSettingsTest extends WP_UnitTestCase
         $valid_formats = ['envelope'];
         $valid_modes = ['sync', 'async'];
 
-        foreach ($valid_formats as $format) {
-            $this->assertContains($format, ['envelope']);
-        }
+        // Verify only envelope format is valid
+        $this->assertEquals(['envelope'], $valid_formats);
 
+        // Verify send modes
         foreach ($valid_modes as $mode) {
             $this->assertContains($mode, ['sync', 'async']);
         }

--- a/tests/unit/SettingsSanitizationTest.php
+++ b/tests/unit/SettingsSanitizationTest.php
@@ -381,6 +381,22 @@ class SettingsSanitizationTest extends TestCase
     }
 
     /**
+     * Test settings sanitization rejects legacy format
+     */
+    public function test_sanitize_settings_legacy_format_rejected()
+    {
+        $input = [
+            'event_format' => 'legacy',
+            'send_mode' => 'async',
+        ];
+
+        $result = $this->instance->sanitize_settings($input);
+
+        // Legacy format should be treated as invalid and default to 'envelope'
+        $this->assertEquals('envelope', $result['event_format']);
+    }
+
+    /**
      * Test settings sanitization rejects invalid send_mode
      */
     public function test_sanitize_settings_invalid_send_mode()


### PR DESCRIPTION
- Update VALID_EVENT_FORMATS constant to only contain 'envelope'
- Remove event_format settings field registration from register_settings()
- Remove render_event_format_field() method entirely
- Update prepare_event_payload() to always use envelope format
- Update handle_test_connection() to always use envelope format
- Update sanitize_settings() to always enforce envelope format

Test updates:
- Update AdminSettingsTest.php to remove legacy format from valid arrays
- Update test_settings_update_flow() to test envelope-to-envelope persistence
- Add test_sanitize_settings_legacy_format_rejected() to verify legacy is rejected
- Update SettingsSanitizationTest.php to expect only envelope as valid format