### PR TITLE
CircleCI に Semgrep CE（SAST）を追加

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   semgrep-scan:
     docker:
-      - image: semgrep/semgrep
+      - image: semgrep/semgrep:1.159.0@sha256:d7d67e1e0c0ed26278ab35f0be082f0afdfd7a880f4927aee86f8127fdbce617
     resource_class: small
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,53 @@
+version: 2.1
+
+jobs:
+  semgrep-scan:
+    docker:
+      - image: semgrep/semgrep
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Create output directory
+          command: mkdir -p /tmp/semgrep
+      - run:
+          name: Semgrep scan (JSON for artifacts)
+          command: |
+            semgrep scan \
+              --config p/default \
+              --config p/php \
+              --json \
+              --output /tmp/semgrep/results.json \
+              .
+      - run:
+          name: Semgrep scan (JUnit XML for Tests tab)
+          command: |
+            semgrep scan \
+              --config p/default \
+              --config p/php \
+              --error \
+              --junit-xml \
+              --output /tmp/semgrep/results.xml \
+              .
+      - store_test_results:
+          path: /tmp/semgrep
+      - store_artifacts:
+          path: /tmp/semgrep/results.json
+          destination: semgrep/results.json
+
+workflows:
+  # Runs on every commit (PR branches included when CircleCI builds them).
+  security:
+    jobs:
+      - semgrep-scan
+
+  # Weekly full scan on default branch (registry rules evolve over time).
+  security-weekly:
+    triggers:
+      - schedule:
+          cron: "0 3 * * 1"
+          filters:
+            branches:
+              only: main
+    jobs:
+      - semgrep-scan

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,10 @@
+# Dependencies (never ship with plugin; no need to scan)
+node_modules/
+vendor/
+
+# Build / env artifacts
+dist/
+build/
+
+# Test doubles and fixtures (may trigger security-style rules intentionally)
+tests/fixtures/

--- a/event-publisher-on-aws.php
+++ b/event-publisher-on-aws.php
@@ -1615,6 +1615,7 @@ class EventBridgePostEvents
 
         // Try using tail command if available (most efficient)
         if (function_exists('shell_exec') && !ini_get('safe_mode')) {
+            // nosemgrep: php.lang.security.exec-use.exec-use — line count is cast to int; path is escapeshellarg()
             $tail_output = @shell_exec('tail -n ' . (int)$num_lines . ' ' . escapeshellarg($file_path) . ' 2>&1');
             if ($tail_output !== null && $tail_output !== '') {
                 // Check if output looks like an error (contains "tail:" or similar)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

WordPress プラグイン向けに [Semgrep Community Edition](https://semgrep.dev/docs/semgrep-pro-vs-oss) を CircleCI で実行する静的解析（SAST）を追加しました。記事（CircleCI × Semgrep）と同様に `semgrep scan` + `p/default` をベースに、PHP 向けに `p/php` を併用しています。

## 変更内容

- **`.circleci/config.yml`**: `semgrep/semgrep` イメージでのスキャンジョブ
  - イメージは **`semgrep/semgrep:1.159.0@sha256:...`** にタグ＋digest で固定（CI の再現性）
  - JSON を Artifacts に保存
  - JUnit XML を `store_test_results` で Tests タブに表示（記事の 2 段実行パターン）
  - **`security` ワークフロー**: プッシュごと（PR を CircleCI がビルドする設定なら PR ごとも）
  - **`security-weekly` ワークフロー**: `main` のみ、毎週月曜 03:00 UTC のスケジュール（レジストリのルール更新を週次で拾う用途）
- **`.semgrepignore`**: `vendor/`、`node_modules/`、`tests/fixtures/` を除外（フィクスチャ由来のノイズ低減）
- **`event-publisher-on-aws.php`**: `read_last_lines` 内の `shell_exec` に対する Semgrep の誤検知を、ルール ID 付き `nosemgrep` で抑制（行数は `(int)`、パスは `escapeshellarg()` で固定）

## 運用上の注意

- CircleCI プロジェクトを本リポジトリに接続し、**このブランチまたは `main` マージ後にパイプラインが走ること**を確認してください。
- CE は単一ファイル／単一関数スコープの解析に限られます。クロスファイルのデータフローが必要な場合は Semgrep AppSec Platform の検討がドキュメント上の次の段階になります。

## ローカル検証

エージェント環境で `semgrep scan --config p/default --config p/php --error .` を実行し、0 findings を確認済みです。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2eb3546a-8ac0-4383-8fed-9b36028ac674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2eb3546a-8ac0-4383-8fed-9b36028ac674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

